### PR TITLE
企業個別ページ用バックエンドAPI実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 logs
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -713,6 +713,14 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-cli": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
@@ -3479,6 +3487,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.0.tgz",
+      "integrity": "sha512-yy3x9XjojW8ROTBePD25AcMoHqGHsvHmtfw8QWlpEXyMMXXPj6brUA464AptUvHuTPRmNz6Sd3ZLNLeJl6dHJA=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -4532,8 +4545,7 @@
     "follow-redirects": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
-      "dev": true
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
         ]
     },
     "dependencies": {
+        "axios": "^0.21.1",
         "config": "^3.3.6",
+        "dotenv": "^9.0.0",
         "express": "^4.17.1",
         "log4js": "^6.3.0",
         "react": "^17.0.2",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-fetch('/api/symbol/test/AAPL').then(response => {
+fetch('/api/symbol/AAPL').then(response => {
     console.log(response.json());
 })  
 

--- a/src/server/apis/getStockData.js
+++ b/src/server/apis/getStockData.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const { logger } = require('../logger');
+const axios = require('axios');
+
+async function execStockApi(symbol, type){
+    return new Promise(function(resolve, reject) {
+        axios
+            .get(process.env.IEX_API_SANDBOX_BASE_URL + 'stock/' + symbol + '/' + type + '?token=' + process.env.IEX_SANDBOX_SECRET_TOKEN)
+            .then(response => resolve(response.data))
+            .catch(error => reject(error.response))
+    });
+}
+
+exports.getStockQuote = function(symbol){
+    return execStockApi(symbol, "quote")
+}
+
+exports.getStockLogo = function(symbol){
+    return execStockApi(symbol, 'logo')
+}
+
+exports.getStockStats = function(symbol) {
+    return execStockApi(symbol, 'stats')
+}
+
+exports.getStockAdvancedStats = function(symbol) {
+    return execStockApi(symbol, 'advanced-stats')
+}

--- a/src/server/routes/Symbol.js
+++ b/src/server/routes/Symbol.js
@@ -1,8 +1,54 @@
 const express = require('express');
 const { logger } = require('../logger');
 const router = express.Router();
+const getStockData = require('../apis/getStockData');
+const { get } = require('config');
+const { response } = require('express');
 
 router.use(express.json());
+
+router.get('/:symbol', (req, res) => {
+    const symbol = req.params.symbol
+    Promise.all([ 
+        getStockData.getStockQuote(symbol),
+        getStockData.getStockLogo(symbol),
+        getStockData.getStockAdvancedStats(symbol)
+    ])
+        .then(function (results) {
+            //close(終値)とpreviousClose(前日終値)の差分を追加
+            let addedQuote = Object.assign(results[0], {close_previousClose_diff :results[0]['close'] - results[0]['previousClose']})
+            let quoteAndLogo = Object.assign(addedQuote, results[1])
+            let allGetData = Object.assign(quoteAndLogo, results[2])
+            const returnKeys = [
+                'symbol',
+                'url',
+                'company_name',
+                'close',
+                'close_previousClose_diff',
+                'high',
+                'low',
+                'volume',
+                'week52high',
+                'week52low',
+                'day200MovingAvg',
+                'day50MovingAvg',
+                'avg10Volume',
+                'avg30Volume',
+                'enterpriseValue',
+                'priceToSales',
+                'enterpriseValueToRevenue',
+                'EBITDA'
+            ];
+            const responseData = {}
+            Object.keys(allGetData).map(function (key) {
+                if (returnKeys.indexOf(key) >= 0) {
+                    responseData[key] = allGetData[key]
+                }
+            })
+            logger.info(JSON.stringify(responseData))
+            res.json(JSON.stringify(responseData))
+        });
+})
 
 router.get('/test/:symbol', (req, res)=>{
     res.json({

--- a/src/server/routes/Symbol.js
+++ b/src/server/routes/Symbol.js
@@ -22,7 +22,7 @@ router.get('/:symbol', (req, res) => {
             const returnKeys = [
                 'symbol',
                 'url',
-                'company_name',
+                'companyName',
                 'close',
                 'close_previousClose_diff',
                 'high',
@@ -54,7 +54,7 @@ router.get('/test/:symbol', (req, res)=>{
     res.json({
         "symbol": "APPL",
         "url": "https://storage.googleapis.com/iex/api/logos/AAPL.png",
-        "company_name": "Apple Inc.",
+        "companyName": "Apple Inc.",
         "close": 28.81,
         "diff": 3.23,
         "high": 29.12,


### PR DESCRIPTION
ticket URL(youtrack)
https://makotoagile.myjetbrains.com/youtrack/issue/INVEST-19

reviewer
@makoto15 

実装の概要
企業個別ページ（showページ実装に必要なバックエンドAPIを作成）

api/symbol/:symbolでエンドポイント作成
↓例）Appleの場合
```
GET http://localhost:3000/api/symbol/AAPL
```

↓返ってくるjsonレスポンス
```json
symbol: 'AAPL',
companyName:"Apple Inc"
close: 136.6,
high: 131.546,
low: 132.681,
volume: 80552527,
close_previousClose_diff: 4.549999999999983,
url: '/gp/ocsp/loaoeolcoxssgiolhgd.p:ipt.hAogg./tauePge/mnA7p/-3asiLtorl',
EBITDA: 102136367752,
enterpriseValue: 2332584199805,
enterpriseValueToRevenue: 7.07,
priceToSales: 7.01,
week52high: 149.97,
week52low: 75.3,
avg10Volume: 95379323,
avg30Volume: 94585143,
day200MovingAvg: 131,
day50MovingAvg: 131.25
```
確認してほしいこと(URLを添えて)
iexcloudのAPI叩いてるからトークンとかは.envファイルに書いてるので、それはDMで渡す
その他懸念（あれば）
